### PR TITLE
fix: fix RBS::ParsingError on multiple devise mappings

### DIFF
--- a/lib/rbs_devise/devise.rb
+++ b/lib/rbs_devise/devise.rb
@@ -100,9 +100,9 @@ module  RbsDevise
           class DeviseController < #{parent_controller}
             def find_message: (String | Symbol kind, ?Hash[untyped, untyped] options) -> String
             def navigational_formats: () -> Array[Mime::Type]
-            def resource: () -> #{resource_classes.join(" | ")}
+            def resource: () -> (#{resource_classes.join(" | ")})
             def resource=: #{resource_classes.map { |klass| "(#{klass}) -> #{klass}" }.join(" | ")}
-            def resource_class: () -> #{resource_classes.map { |klass| "singleton(#{klass})" }.join(" | ")}
+            def resource_class: () -> (#{resource_classes.map { |klass| "singleton(#{klass})" }.join(" | ")})
             def resource_name: () -> Symbol
           end
         RBS

--- a/spec/rbs_devise/devise_spec.rb
+++ b/spec/rbs_devise/devise_spec.rb
@@ -6,6 +6,9 @@ require "rbs_devise"
 class User
 end
 
+class Account
+end
+
 RSpec.describe RbsDevise::Devise do
   describe ".available?" do
     subject { described_class.available? }
@@ -81,6 +84,78 @@ RSpec.describe RbsDevise::Devise do
             def resource: () -> User
             def resource=: (User) -> User
             def resource_class: () -> singleton(User)
+            def resource_name: () -> Symbol
+          end
+
+          class ActionController::Base
+            include Devise::Helpers
+          end
+
+          class ActiveRecord::Base
+            extend Devise::Models
+          end
+        RBS
+      end
+    end
+
+    context "When devise mapping has multiple definitions" do
+      before { allow(Devise).to receive(:mappings).and_return({ user: User, account: Account }) }
+
+      it "generates RBS" do
+        is_expected.to eq <<~RBS
+          module Devise
+            module Controllers
+              module SignInOut
+                def signed_in?: (User | Account | nil scope) -> bool
+
+                def sign_in: (Symbol scope) -> void
+                           | (User | Account resource, **untyped options) -> void
+
+                def bypass_sign_in: (User | Account resource, ?scope: Symbol?) -> void
+
+                def sign_out: (Symbol scope) -> bool
+                            | (User | Account resource) -> bool
+
+                def sign_out_all_scopes: (?bool lock) -> bool
+              end
+            end
+
+            module Helpers
+              include Devise::Controllers::SignInOut
+
+              def authenticate_user!: (?Hash[untyped, untyped] opts) -> void
+
+              def user_signed_in?: () -> bool
+
+              def current_user: () -> User
+
+              def user_session: () -> untyped
+
+              def authenticate_account!: (?Hash[untyped, untyped] opts) -> void
+
+              def account_signed_in?: () -> bool
+
+              def current_account: () -> Account
+
+              def account_session: () -> untyped
+            end
+
+            module Models
+              def devise: (*Symbol) -> void
+            end
+
+            class SessionsController < DeviseController
+              def sign_in_params: () -> Hash[untyped, untyped]
+            end
+          end
+
+          class DeviseController < ApplicationController
+            def find_message: (String | Symbol kind, ?Hash[untyped, untyped] options) -> String
+            def navigational_formats: () -> Array[Mime::Type]
+            def resource: () -> (User | Account)
+            def resource=: (User) -> User
+                         | (Account) -> Account
+            def resource_class: () -> (singleton(User) | singleton(Account))
             def resource_name: () -> Symbol
           end
 


### PR DESCRIPTION
```
  1) RbsDevise::Devise.generate When devise mapping has multiple definitions generates RBS
     Failure/Error: parsed = RBS::Parser.parse_signature(rbs)

     RBS::ParsingError:
       a.rbs:40:29...40:36: Syntax error: unexpected token for method type, token=`Account` (tUIDENT)
     # ./lib/rbs_devise/devise.rb:37:in `format'
     # ./lib/rbs_devise/devise.rb:20:in `generate'
     # ./lib/rbs_devise/devise.rb:15:in `generate'
     # ./spec/rbs_devise/devise_spec.rb:30:in `block (3 levels) in <top (required)>'
     # ./spec/rbs_devise/devise_spec.rb:105:in `block (4 levels) in <top (required)>'
```