### PR TITLE
Add RBS type annotations using rbs-inline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   TargetRubyVersion: 3.1
 
+Layout/LeadingCommentSpace:
+  AllowRBSInlineAnnotation: true
+
 Style/Documentation:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rake", "~> 13.4"
 gem "rubocop", "~> 1.88"
 
 group :deveopment do
+  gem "rbs-inline", require: false
   gem "rspec", require: false
   gem "rspec-daemon", require: false
   gem "steep", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,6 @@ GEM
       net-smtp
     mini_mime (1.1.5)
     minitest (5.27.0)
-    mutex_m (0.3.0)
     net-imap (0.5.15)
       date
       net-protocol
@@ -171,9 +170,13 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.10.4)
+    rbs (4.0.3)
       logger
+      prism (>= 1.6.0)
       tsort
+    rbs-inline (0.14.0)
+      prism (>= 0.29)
+      rbs (~> 4.0)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -215,8 +218,7 @@ GEM
       prism (~> 1.7)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    steep (1.10.0)
-      activesupport (>= 5.1)
+    steep (2.0.0)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
       fileutils (>= 1.1.0)
@@ -224,10 +226,10 @@ GEM
       language_server-protocol (>= 3.17.0.4, < 4.0)
       listen (~> 3.0)
       logger (>= 1.3.0)
-      mutex_m (>= 0.3.0)
-      parser (>= 3.1)
+      parser (>= 3.2)
+      prism (>= 0.25.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 3.9)
+      rbs (~> 4.0)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 5)
@@ -258,6 +260,7 @@ PLATFORMS
 
 DEPENDENCIES
   rake (~> 13.4)
+  rbs-inline
   rbs_devise!
   rspec
   rspec-daemon

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,11 @@ namespace :rbs do
     sh "bundle exec rbs collection install --frozen"
   end
 
+  desc "Generate RBS files"
+  task :generate do
+    sh "rbs-inline", "--opt-out", "--output=sig", "lib"
+  end
+
   desc "Validate RBS files"
   task validate: "rbs:install" do
     sh "bundle exec rbs -Isig validate"

--- a/lib/generators/rbs_devise/install_generator.rb
+++ b/lib/generators/rbs_devise/install_generator.rb
@@ -4,7 +4,7 @@ require "rails"
 
 module RbsDevise
   class InstallGenerator < ::Rails::Generators::Base
-    def create_raketask
+    def create_raketask #: void
       create_file "lib/tasks/rbs_devise.rake", <<~RUBY
         # frozen_string_literal: true
 

--- a/lib/rbs_devise/devise.rb
+++ b/lib/rbs_devise/devise.rb
@@ -5,18 +5,18 @@ require "rbs"
 
 module  RbsDevise
   module Devise
-    def self.available?
+    def self.available? #: bool
       ::Devise.mappings.any?
     end
 
-    def self.generate
+    def self.generate #: String
       raise unless available?
 
       Generator.new.generate
     end
 
     class Generator
-      def generate
+      def generate #: String
         format <<~RBS
           module Devise
             #{devise_controllers_signinout_decl}
@@ -33,14 +33,15 @@ module  RbsDevise
 
       private
 
-      def format(rbs)
+      # @rbs rbs: String
+      def format(rbs) #: String
         parsed = RBS::Parser.parse_signature(rbs)
         StringIO.new.tap do |out|
           RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
         end.string
       end
 
-      def devise_controllers_signinout_decl
+      def devise_controllers_signinout_decl #: String
         resource_type = resource_classes.join(" | ")
         <<~RBS
           module Controllers
@@ -57,7 +58,7 @@ module  RbsDevise
         RBS
       end
 
-      def device_helpers_decl
+      def device_helpers_decl #: String
         <<~RBS
           module Helpers
             include Devise::Controllers::SignInOut
@@ -67,7 +68,7 @@ module  RbsDevise
         RBS
       end
 
-      def device_helpers_methods
+      def device_helpers_methods #: String
         resource_classes.map do |klass_name|
           resource = klass_name.underscore
           <<~RBS.strip
@@ -79,7 +80,7 @@ module  RbsDevise
         end.join("\n")
       end
 
-      def device_models_decl
+      def device_models_decl #: String
         <<~RBS
           module Models
             def devise: (*Symbol) -> void
@@ -87,7 +88,7 @@ module  RbsDevise
         RBS
       end
 
-      def devise_sessions_controller_decl
+      def devise_sessions_controller_decl #: String
         <<~RBS
           class SessionsController < DeviseController
             def sign_in_params: () -> Hash[untyped, untyped]
@@ -95,7 +96,7 @@ module  RbsDevise
         RBS
       end
 
-      def devise_controller_decl
+      def devise_controller_decl #: String
         <<~RBS
           class DeviseController < #{parent_controller}
             def find_message: (String | Symbol kind, ?Hash[untyped, untyped] options) -> String
@@ -108,7 +109,7 @@ module  RbsDevise
         RBS
       end
 
-      def actioncontroller_base_decl
+      def actioncontroller_base_decl #: String
         <<~RBS
           class ActionController::Base
             include Devise::Helpers
@@ -116,7 +117,7 @@ module  RbsDevise
         RBS
       end
 
-      def activerecord_base_decl
+      def activerecord_base_decl #: String
         <<~RBS
           class ActiveRecord::Base
             extend Devise::Models
@@ -124,11 +125,11 @@ module  RbsDevise
         RBS
       end
 
-      def parent_controller
+      def parent_controller #: String
         ::Devise.parent_controller
       end
 
-      def resource_classes
+      def resource_classes #: Array[String]
         ::Devise.mappings.keys.map(&:to_s).map(&:camelcase)
       end
     end

--- a/lib/rbs_devise/rake_task.rb
+++ b/lib/rbs_devise/rake_task.rb
@@ -4,9 +4,12 @@ require "rake/tasklib"
 
 module RbsDevise
   class RakeTask < Rake::TaskLib
-    attr_accessor :name, :signature_root_dir
+    attr_accessor :name #: Symbol
+    attr_accessor :signature_root_dir #: Pathname
 
-    def initialize(name = :"rbs:devise", &block)
+    # @rbs name: Symbol
+    # @rbs &block: (RakeTask) -> void
+    def initialize(name = :"rbs:devise", &block) #: void
       super()
 
       @name = name
@@ -18,14 +21,14 @@ module RbsDevise
       define_setup_task
     end
 
-    def define_setup_task
+    def define_setup_task #: void
       desc "Run all tasks of rbs_devise"
 
       deps = [:"#{name}:generate"]
       task("#{name}:setup" => deps)
     end
 
-    def define_generate_task
+    def define_generate_task #: void
       desc "Generate a RBS file for Devise"
       task("#{name}:generate": :environment) do
         require "rbs_devise" # load RbsDevise lazily

--- a/sig/generators/rbs_devise/install_generator.rbs
+++ b/sig/generators/rbs_devise/install_generator.rbs
@@ -1,3 +1,5 @@
+# Generated from lib/generators/rbs_devise/install_generator.rb with RBS::Inline
+
 module RbsDevise
   class InstallGenerator < ::Rails::Generators::Base
     def create_raketask: () -> void

--- a/sig/rbs_devise.rbs
+++ b/sig/rbs_devise.rbs
@@ -1,4 +1,6 @@
+# Generated from lib/rbs_devise.rb with RBS::Inline
+
 module RbsDevise
-  VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
+  class Error < StandardError
+  end
 end

--- a/sig/rbs_devise/devise.rbs
+++ b/sig/rbs_devise/devise.rbs
@@ -1,6 +1,9 @@
-module  RbsDevise
+# Generated from lib/rbs_devise/devise.rb with RBS::Inline
+
+module RbsDevise
   module Devise
     def self.available?: () -> bool
+
     def self.generate: () -> String
 
     class Generator
@@ -8,16 +11,27 @@ module  RbsDevise
 
       private
 
+      # @rbs rbs: String
       def format: (String rbs) -> String
+
       def devise_controllers_signinout_decl: () -> String
+
       def device_helpers_decl: () -> String
+
       def device_helpers_methods: () -> String
+
       def device_models_decl: () -> String
-      def devise_controller_decl: () -> String
+
       def devise_sessions_controller_decl: () -> String
+
+      def devise_controller_decl: () -> String
+
       def actioncontroller_base_decl: () -> String
+
       def activerecord_base_decl: () -> String
+
       def parent_controller: () -> String
+
       def resource_classes: () -> Array[String]
     end
   end

--- a/sig/rbs_devise/rake_task.rbs
+++ b/sig/rbs_devise/rake_task.rbs
@@ -1,10 +1,17 @@
+# Generated from lib/rbs_devise/rake_task.rb with RBS::Inline
+
 module RbsDevise
   class RakeTask < Rake::TaskLib
     attr_accessor name: Symbol
+
     attr_accessor signature_root_dir: Pathname
 
-    def initialize: (?Symbol name) ? { (RakeTask) -> void } -> void
+    # @rbs name: Symbol
+    # @rbs &block: (RakeTask) -> void
+    def initialize: (?Symbol name) { (RakeTask) -> void } -> void
+
     def define_setup_task: () -> void
+
     def define_generate_task: () -> void
   end
 end

--- a/sig/rbs_devise/version.rbs
+++ b/sig/rbs_devise/version.rbs
@@ -1,0 +1,5 @@
+# Generated from lib/rbs_devise/version.rb with RBS::Inline
+
+module RbsDevise
+  VERSION: ::String
+end


### PR DESCRIPTION
## Summary
This PR adds comprehensive RBS (Ruby Type Signature) annotations to the codebase using the `rbs-inline` gem. Type annotations are embedded directly in Ruby source files as comments, which are then extracted to generate corresponding `.rbs` signature files.

## Key Changes

- **Added inline RBS annotations** to all public and private methods across the codebase using `#: Type` comment syntax
- **Generated RBS signature files** from inline annotations:
  - `sig/rbs_devise/devise.rbs` - Updated with generated signatures
  - `sig/rbs_devise/rake_task.rbs` - Updated with generated signatures
  - `sig/rbs_devise.rbs` - Simplified to include only `Error` class definition
  - `sig/rbs_devise/version.rbs` - New file with `VERSION` constant signature
  - `sig/generators/rbs_devise/install_generator.rbs` - Updated with generated signatures

- **Added RBS generation task** to Rakefile:
  - New `rbs:generate` task that runs `rbs-inline` to extract annotations from source files

- **Updated RuboCop configuration** to allow RBS inline annotations in comments via `AllowRBSInlineAnnotation: true`

- **Added `rbs-inline` gem** to development dependencies

## Notable Implementation Details

- Type annotations follow RBS syntax conventions (e.g., `#: bool`, `#: String`, `#: Array[String]`)
- Multi-line documentation for complex signatures uses `@rbs` tags
- All generated RBS files include a header comment indicating they were auto-generated
- The inline annotation approach allows type information to live alongside implementation code
- Spacing and formatting improvements in RBS files for better readability

https://claude.ai/code/session_01Kd5qB3YJEc37bdmRzcTF2B