### PR TITLE
Introduce rubocop-numbered-params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   TargetRubyVersion: 3.1
 
+plugins:
+  - rubocop-numbered-params
+
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem "rake", "~> 13.4"
 
 gem "rubocop", "~> 1.88"
+gem "rubocop-numbered-params"
 
 group :deveopment do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     erb (4.0.4.1)
       cgi (>= 0.3.3)
     erubi (1.13.1)
+    ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     fileutils (1.7.3)
@@ -118,6 +119,8 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
+    nokogiri (1.19.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
@@ -216,6 +219,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-numbered-params (1.0.0)
+      lint_roller (~> 1.0)
+      rubocop (>= 1.72.1)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     steep (2.0.0)
@@ -253,6 +259,7 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-darwin-23
   x86_64-darwin-24
@@ -265,6 +272,7 @@ DEPENDENCIES
   rspec
   rspec-daemon
   rubocop (~> 1.88)
+  rubocop-numbered-params
   steep
 
 BUNDLED WITH

--- a/lib/rbs_devise/devise.rb
+++ b/lib/rbs_devise/devise.rb
@@ -102,8 +102,8 @@ module  RbsDevise
             def find_message: (String | Symbol kind, ?Hash[untyped, untyped] options) -> String
             def navigational_formats: () -> Array[Mime::Type]
             def resource: () -> (#{resource_classes.join(" | ")})
-            def resource=: #{resource_classes.map { |klass| "(#{klass}) -> #{klass}" }.join(" | ")}
-            def resource_class: () -> (#{resource_classes.map { |klass| "singleton(#{klass})" }.join(" | ")})
+            def resource=: #{resource_classes.map { "(#{_1}) -> #{_1}" }.join(" | ")}
+            def resource_class: () -> (#{resource_classes.map { "singleton(#{_1})" }.join(" | ")})
             def resource_name: () -> Symbol
           end
         RBS

--- a/rbs_devise.gemspec
+++ b/rbs_devise.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "devise"


### PR DESCRIPTION
Add the `rubocop-numbered-params` plugin to enforce a consistent style for numbered block parameters, matching the setup already used in other repositories.

- Add `rubocop-numbered-params` to the Gemfile and Gemfile.lock
- Register the plugin in `.rubocop.yml`
- Autocorrect existing offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)