### PR TITLE
Introduce rubocop-rbs_inline plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,12 +4,22 @@ AllCops:
 plugins:
   - rubocop-numbered-params
   - rubocop-rake
+  - rubocop-rbs_inline
 
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
 
 Style/Documentation:
   Enabled: false
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RequireRbsInlineComment:
+  EnforcedStyle: never
 
 Style/StringLiterals:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rake", "~> 13.4"
 gem "rubocop", "~> 1.88"
 gem "rubocop-numbered-params"
 gem "rubocop-rake"
+gem "rubocop-rbs_inline"
 
 group :deveopment do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,10 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
+    rubocop-rbs_inline (1.5.5)
+      lint_roller (~> 1.1)
+      rbs-inline
+      rubocop (>= 1.72.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     steep (2.0.0)
@@ -277,6 +281,7 @@ DEPENDENCIES
   rubocop (~> 1.88)
   rubocop-numbered-params
   rubocop-rake
+  rubocop-rbs_inline
   steep
 
 BUNDLED WITH


### PR DESCRIPTION
Add the `rubocop-rbs_inline` plugin so this repository lints its RBS::Inline annotations, aligning it with the other repositories that already enable the full plugin set (numbered-params, rake, rbs_inline, rspec).

- Add `rubocop-rbs_inline` to the Gemfile and lockfile
- Register it under `plugins:` in `.rubocop.yml`
- Configure the `Style/RbsInline/*` cops with the same settings used across the sibling repositories (`doc_style_and_return_annotation`, `RequireRbsInlineComment: never`)

`rubocop` reports no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)