### PR TITLE
Introduce rubocop-rspec plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ plugins:
   - rubocop-numbered-params
   - rubocop-rake
   - rubocop-rbs_inline
+  - rubocop-rspec
 
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
@@ -38,3 +39,9 @@ Layout/LineLength:
 
 Layout/MethodLength:
   Max: 20
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rubocop", "~> 1.88"
 gem "rubocop-numbered-params"
 gem "rubocop-rake"
 gem "rubocop-rbs_inline"
+gem "rubocop-rspec"
 
 group :deveopment do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,10 @@ GEM
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)
+    rubocop-rspec (3.10.2)
+      lint_roller (~> 1.1)
+      regexp_parser (>= 2.0)
+      rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     steep (2.0.0)
@@ -282,6 +286,7 @@ DEPENDENCIES
   rubocop-numbered-params
   rubocop-rake
   rubocop-rbs_inline
+  rubocop-rspec
   steep
 
 BUNDLED WITH

--- a/spec/rbs_devise/devise_spec.rb
+++ b/spec/rbs_devise/devise_spec.rb
@@ -13,33 +13,33 @@ RSpec.describe RbsDevise::Devise do
   describe ".available?" do
     subject { described_class.available? }
 
-    context "When no devise mapping is defined" do
+    context "when no devise mapping is defined" do
       before { allow(Devise).to receive(:mappings).and_return({}) }
 
-      it { is_expected.to eq false }
+      it { is_expected.to be false }
     end
 
-    context "When devise mapping is defined" do
+    context "when devise mapping is defined" do
       before { allow(Devise).to receive(:mappings).and_return({ user: User }) }
 
-      it { is_expected.to eq true }
+      it { is_expected.to be true }
     end
   end
 
   describe ".generate" do
     subject { described_class.generate }
 
-    context "When no devise mapping is defined" do
+    context "when no devise mapping is defined" do
       before { allow(Devise).to receive(:mappings).and_return({}) }
 
-      it { expect { subject }.to raise_error }
+      it { expect { subject }.to raise_error(RuntimeError) }
     end
 
-    context "When devise mapping is defined" do
+    context "when devise mapping is defined" do
       before { allow(Devise).to receive(:mappings).and_return({ user: User }) }
 
       it "generates RBS" do
-        is_expected.to eq <<~RBS
+        expect(subject).to eq <<~RBS
           module Devise
             module Controllers
               module SignInOut
@@ -98,11 +98,11 @@ RSpec.describe RbsDevise::Devise do
       end
     end
 
-    context "When devise mapping has multiple definitions" do
+    context "when devise mapping has multiple definitions" do
       before { allow(Devise).to receive(:mappings).and_return({ user: User, account: Account }) }
 
       it "generates RBS" do
-        is_expected.to eq <<~RBS
+        expect(subject).to eq <<~RBS
           module Devise
             module Controllers
               module SignInOut


### PR DESCRIPTION
Add the `rubocop-rspec` plugin so this repository lints its specs, completing the full plugin set (numbered-params, rake, rbs_inline, rspec) shared across the sibling repositories.

- Add `rubocop-rspec` to the Gemfile and lockfile
- Register it under `plugins:` in `.rubocop.yml`
- Configure `RSpec/ExampleLength` and `RSpec/NamedSubject` with the same settings used across the sibling repositories
- Reword `context` descriptions to lowercase `when …` (`RSpec/ContextWording`)
- Replace `eq true`/`eq false` with `be true`/`be false` (`RSpec/BeEq`)
- Specify `RuntimeError` on the `raise_error` matcher (`RSpec/UnspecifiedException`)
- Use an explicit `expect(subject)` instead of the implicit subject inside the named examples (`RSpec/ImplicitSubject`)

`rubocop` reports no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)