### PR TITLE
Align .rubocop.yml with shared skeleton baseline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
+# NOTE: Rules are sorted in ASCII order.
+
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 3.1
 
 plugins:
@@ -7,12 +10,45 @@ plugins:
   - rubocop-rbs_inline
   - rubocop-rspec
 
+# Layout
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
+  AllowSteepAnnotation: true
 
-Style/Documentation:
+Layout/LineLength:
+  Max: 120
+
+# Metrics
+Metrics/AbcSize:
+  Max: 20
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*_spec.rb"
+
+Metrics/ClassLength:
+  Max: 200
+
+Metrics/MethodLength:
+  Max: 30
+
+# RSpec
+RSpec/ExampleLength:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 5
+
+# RbsInline
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
 
@@ -22,26 +58,24 @@ Style/RbsInline/RedundantTypeAnnotation:
 Style/RbsInline/RequireRbsInlineComment:
   EnforcedStyle: never
 
+# Style
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
+Style/RedundantFormat:
+  Enabled: false
+
 Style/StringLiterals:
-  Enabled: true
   EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
-  Enabled: true
   EnforcedStyle: double_quotes
-
-Layout/BlockLength:
-  Exclude:
-    - "spec/**/*_spec.rb"
-
-Layout/LineLength:
-  Max: 120
-
-Layout/MethodLength:
-  Max: 20
-
-RSpec/ExampleLength:
-  Enabled: false
-
-RSpec/NamedSubject:
-  Enabled: false

--- a/lib/rbs_devise/devise.rb
+++ b/lib/rbs_devise/devise.rb
@@ -37,7 +37,7 @@ module  RbsDevise
       def format(rbs) #: String
         parsed = RBS::Parser.parse_signature(rbs)
         StringIO.new.tap do |out|
-          RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
+          RBS::Writer.new(out:).write(parsed[1] + parsed[2])
         end.string
       end
 

--- a/rbs_devise.gemspec
+++ b/rbs_devise.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = spec.homepage
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|

--- a/spec/rbs_devise/devise_spec.rb
+++ b/spec/rbs_devise/devise_spec.rb
@@ -3,10 +3,10 @@
 require "devise"
 require "rbs_devise"
 
-class User
+class User # rubocop:disable Lint/EmptyClass
 end
 
-class Account
+class Account # rubocop:disable Lint/EmptyClass
 end
 
 RSpec.describe RbsDevise::Devise do


### PR DESCRIPTION
## Summary

Align this repository's `.rubocop.yml` with the shared `init-ruby-project`
skeleton so linting rules are consistent across all Ruby repositories, and
fix the offenses the aligned config surfaces.

## Config changes

- **Fix invalid cop names**: `Layout/BlockLength` → `Metrics/BlockLength`
  and `Layout/MethodLength` → `Metrics/MethodLength`. The `Layout/*` names
  do not exist, so those settings previously had no effect.
- Fill in missing cops: `AllCops/NewCops`, `Layout/LeadingCommentSpace`
  `AllowSteepAnnotation`, `Metrics/AbcSize`, `Metrics/ClassLength`,
  `RSpec/MultipleMemoizedHelpers`, `RSpec/MultipleExpectations`,
  `RSpec/NestedGroups`, `Style/AccessorGrouping`, `Style/CommentedKeyword`,
  `Style/HashSyntax`
- `Metrics/MethodLength`: 20 → 30 (match baseline)
- Rules sorted in ASCII order to match the skeleton

## Code changes (offenses surfaced by the new cops)

- `devise.rb`: use `out:` shorthand; `rbs_devise.gemspec`: set
  `rubygems_mfa_required`
- `devise_spec.rb`: disable `Lint/EmptyClass` on the fixture classes
  (matches the rbs_active_hash convention)
- Disable `Style/RedundantFormat`: the local `format` method is not
  `Kernel#format`, so the cop is a false positive here

Verified locally with `rubocop` (no offenses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)