### PR TITLE
Add strscan to rbs_collection as a workaround

### DIFF
--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -349,6 +349,10 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: strscan
+  version: '0'
+  source:
+    type: stdlib
 - name: tempfile
   version: '0'
   source:

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -18,3 +18,4 @@ gems:
   # It's unnecessary if you don't use rbs as a library.
 
   - name: pathname
+  - name: strscan


### PR DESCRIPTION
## Summary

`rbs validate` currently fails because of a bug in `rbs-inline`: the generated RBS references `StringScanner`, but `strscan`'s RBS is not loaded by the collection.

A fix has been submitted upstream. Until it is merged, this PR works around the failure by adding `strscan` to `rbs_collection.yaml` and reflecting it in the lock file.

## Changes

- Add `- name: strscan` to `rbs_collection.yaml`
- Add the corresponding `strscan` entry to `rbs_collection.lock.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)